### PR TITLE
Fix staff service method and relax Ruby version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.0.4"
+ruby ">= 3.0.4"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ DEPENDENCIES
   webdrivers
 
 RUBY VERSION
-   ruby 3.0.4p208
+   ruby 3.2.3p157
 
 BUNDLED WITH
-   2.2.33
+   2.4.19

--- a/app/controllers/correct_use_of_interface_segregation_principle_in_ruby.rb
+++ b/app/controllers/correct_use_of_interface_segregation_principle_in_ruby.rb
@@ -66,7 +66,7 @@ class CoffeeMachineUserInterface
       @coffee_machine = CoffeeMachineServiceInterface.new
     end
   
-    def serv
+    def service
       @coffee_machine.clean_coffee_machine
       @coffee_machine.fill_coffee_beans
       @coffee_machine.fill_water_supply

--- a/app/controllers/violation_of_interface_segregation_principle_in_ruby.rb
+++ b/app/controllers/violation_of_interface_segregation_principle_in_ruby.rb
@@ -60,7 +60,7 @@ class CoffeeMachineInterface
       @coffee_machine = CoffeeMachineInterface.new
     end
   
-    def serv
+    def service
       @coffee_machine.clean_coffee_machine
       @coffee_machine.fill_coffee_beans
       @coffee_machine.fill_water_supply


### PR DESCRIPTION
## Summary
- rename staff `serv` method to `service` in interface segregation examples
- relax required Ruby version and align Gemfile.lock

## Testing
- `bundle exec rake test` *(fails: Could not find rails-7.0.3 and other gems)*

------
https://chatgpt.com/codex/tasks/task_e_689075e917988328980a118fa5987b2d