### PR TITLE
Rename serv method for clarity in interface segregation examples

### DIFF
--- a/app/controllers/correct_use_of_interface_segregation_principle_in_ruby.rb
+++ b/app/controllers/correct_use_of_interface_segregation_principle_in_ruby.rb
@@ -66,7 +66,7 @@ class CoffeeMachineUserInterface
       @coffee_machine = CoffeeMachineServiceInterface.new
     end
   
-    def serv
+    def service_machine
       @coffee_machine.clean_coffee_machine
       @coffee_machine.fill_coffee_beans
       @coffee_machine.fill_water_supply

--- a/app/controllers/violation_of_interface_segregation_principle_in_ruby.rb
+++ b/app/controllers/violation_of_interface_segregation_principle_in_ruby.rb
@@ -60,7 +60,7 @@ class CoffeeMachineInterface
       @coffee_machine = CoffeeMachineInterface.new
     end
   
-    def serv
+    def service_machine
       @coffee_machine.clean_coffee_machine
       @coffee_machine.fill_coffee_beans
       @coffee_machine.fill_water_supply


### PR DESCRIPTION
## Summary
- rename `serv` to `service_machine` in interface segregation examples for clarity

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.0.4)*

------
https://chatgpt.com/codex/tasks/task_e_68908154d00c832897f4d589cc073e97